### PR TITLE
feat: add collect-then-iterate AST rule (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ That's it. With zero configuration you get:
 - **inline-comments** — flags functions with excessive `//` comments (ratio > 30% or > 3 consecutive)
 - **redundant-comments** — flags `//` comments that restate the code they describe (e.g., `// increment counter` above `counter += 1`)
 - **clone-density** — flags functions with too many `.clone()` calls (> 5 calls or > 10% ratio in 10+ statement functions)
+- **collect-then-iterate** — flags `.collect().iter()` and similar anti-patterns where a collection is built only to be immediately iterated
 - **glob-imports** — flags `use foo::*` wildcard imports that make it hard to track symbol origins
 
 ## Usage
@@ -217,6 +218,22 @@ Two checks are performed:
 |---|---|---|
 | `max_clones_per_fn` | `5` | Maximum number of `.clone()` calls per function |
 | `max_clone_ratio` | `0.1` | Maximum ratio of `.clone()` calls to total statements (0.0–1.0) |
+
+### collect-then-iterate
+
+Flags `.collect().iter()` and similar anti-patterns where a collection is built only to be immediately consumed. This allocates unnecessarily and is common in AI-generated code. Clippy does not catch this pattern.
+
+Detected patterns and their suggestions:
+
+| Follow-up method | Suggestion |
+|---|---|
+| `.iter()`, `.into_iter()`, `.iter_mut()` | Continue using the iterator chain directly |
+| `.len()` | Use `.count()` instead |
+| `.is_empty()` | Use `.next().is_none()` instead |
+| `.first()` | Use `.next()` instead |
+| `.last()` | Use `.last()` on the iterator instead |
+
+Only immediate chaining is flagged (e.g., `.collect().iter()`). Intermediate method calls (`.collect().as_slice().iter()`) and variable bindings (`let v = .collect(); v.iter()`) are not flagged. Both turbofish (`.collect::<Vec<_>>()`) and plain `.collect()` are detected.
 
 ### glob-imports
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub use crate::rule_registry::{RulesConfig, TestRulesOverrides};
 // Re-export per-rule config types for backward compatibility
 pub use crate::rules::ast::allow_audit::Config as AllowAuditConfig;
 pub use crate::rules::ast::clone_density::Config as CloneDensityConfig;
+pub use crate::rules::ast::collect_then_iterate::Config as CollectThenIterateConfig;
 pub use crate::rules::ast::glob_imports::Config as GlobImportsConfig;
 pub use crate::rules::ast::magic_numbers::Config as MagicNumbersConfig;
 pub use crate::rules::ast::undocumented_panic::Config as UndocumentedPanicConfig;
@@ -20,6 +21,7 @@ pub use crate::rules::text::todo_comments::Config as TodoCommentsConfig;
 // Re-export per-rule override types for backward compatibility
 pub use crate::rules::ast::allow_audit::Override as AllowAuditOverride;
 pub use crate::rules::ast::clone_density::Override as CloneDensityOverride;
+pub use crate::rules::ast::collect_then_iterate::Override as CollectThenIterateOverride;
 pub use crate::rules::ast::glob_imports::Override as GlobImportsOverride;
 pub use crate::rules::ast::magic_numbers::Override as MagicNumbersOverride;
 pub use crate::rules::ast::undocumented_panic::Override as UndocumentedPanicOverride;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -212,7 +212,7 @@ mod tests {
         let config = Config::default();
         let engine = Engine::new(&config);
         assert_eq!(engine.prod_text_rules.len(), 5);
-        assert_eq!(engine.prod_ast_rules.len(), 2);
+        assert_eq!(engine.prod_ast_rules.len(), 3);
         assert!(engine.test_text_rules.is_empty());
         assert!(engine.test_ast_rules.is_empty());
         assert!(engine.test_config.is_none());
@@ -228,7 +228,7 @@ mod tests {
         assert_eq!(engine.prod_text_rules.len(), 5);
         // Test rules should mirror prod when no overrides
         assert_eq!(engine.test_text_rules.len(), 5);
-        assert_eq!(engine.test_ast_rules.len(), 2);
+        assert_eq!(engine.test_ast_rules.len(), 3);
         assert!(engine.test_config.is_some());
     }
 

--- a/src/rule_registry.rs
+++ b/src/rule_registry.rs
@@ -105,6 +105,7 @@ declare_rules! {
     ast {
         allow_audit: "allow-audit",
         clone_density: "clone-density",
+        collect_then_iterate: "collect-then-iterate",
         glob_imports: "glob-imports",
         magic_numbers: "magic-numbers",
         undocumented_panic: "undocumented-panic",

--- a/src/rules/ast/collect_then_iterate.rs
+++ b/src/rules/ast/collect_then_iterate.rs
@@ -1,0 +1,260 @@
+use crate::diagnostic::{Diagnostic, RuleLevel};
+use crate::rules::AstRule;
+use serde::Deserialize;
+use std::path::Path;
+use syn::visit::Visit;
+
+// --- Config ---
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub level: RuleLevel,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            level: RuleLevel::Warn,
+        }
+    }
+}
+
+// --- Test Override ---
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct Override {
+    pub level: Option<RuleLevel>,
+}
+
+pub const fn apply_override(cfg: &mut Config, o: &Override) {
+    if let Some(v) = o.level {
+        cfg.level = v;
+    }
+}
+
+// --- Rule ---
+pub struct Rule {
+    level: RuleLevel,
+}
+
+impl Rule {
+    pub const fn new(config: &Config) -> Self {
+        Self {
+            level: config.level,
+        }
+    }
+}
+
+impl AstRule for Rule {
+    fn name(&self) -> &'static str {
+        "collect-then-iterate"
+    }
+
+    fn check_file(&self, syntax: &syn::File, _content: &str, file: &Path) -> Vec<Diagnostic> {
+        let mut visitor = CollectIterVisitor {
+            level: self.level,
+            file,
+            diagnostics: Vec::new(),
+        };
+        visitor.visit_file(syntax);
+        visitor.diagnostics
+    }
+}
+
+struct CollectIterVisitor<'a> {
+    level: RuleLevel,
+    file: &'a Path,
+    diagnostics: Vec<Diagnostic>,
+}
+
+fn suggestion_for_method(method: &str) -> Option<&'static str> {
+    match method {
+        "iter" | "into_iter" | "iter_mut" => Some("continue using the iterator chain directly"),
+        "len" => Some("use `.count()` instead"),
+        "is_empty" => Some("use `.next().is_none()` instead"),
+        "first" => Some("use `.next()` instead"),
+        "last" => Some("use `.last()` on the iterator instead"),
+        _ => None,
+    }
+}
+
+fn is_collect_call(expr: &syn::Expr) -> bool {
+    if let syn::Expr::MethodCall(call) = expr {
+        call.method == "collect"
+    } else {
+        false
+    }
+}
+
+impl CollectIterVisitor<'_> {
+    fn emit(&mut self, line: usize, method: &str, suggestion: &str) {
+        let message = format!("`.collect().{method}()` allocates unnecessarily; {suggestion}",);
+        self.diagnostics.push(
+            Diagnostic::new("collect-then-iterate", self.level, message, self.file).with_line(line),
+        );
+    }
+}
+
+impl<'ast> Visit<'ast> for CollectIterVisitor<'_> {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if let Some(suggestion) = suggestion_for_method(&method)
+            && is_collect_call(&node.receiver)
+        {
+            let line = node.method.span().start().line;
+            self.emit(line, &method, suggestion);
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn parse_and_check(code: &str) -> Vec<Diagnostic> {
+        parse_and_check_with_config(
+            code,
+            &Config {
+                level: RuleLevel::Warn,
+            },
+        )
+    }
+
+    fn parse_and_check_with_config(code: &str, config: &Config) -> Vec<Diagnostic> {
+        let syntax = syn::parse_file(code).expect("failed to parse test code");
+        let rule = Rule::new(config);
+        rule.check_file(&syntax, code, Path::new("test.rs"))
+    }
+
+    #[test]
+    fn test_collect_iter_detected() {
+        let code = "fn f() { let _: Vec<i32> = vec![1,2,3].into_iter().collect::<Vec<_>>().iter().count(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains(".collect().iter()"));
+        assert!(diags[0].message.contains("iterator chain directly"));
+    }
+
+    #[test]
+    fn test_collect_into_iter_detected() {
+        let code = "fn f() { let _v: Vec<i32> = vec![1].into_iter().collect::<Vec<_>>().into_iter().count(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("into_iter"));
+    }
+
+    #[test]
+    fn test_collect_iter_mut_detected() {
+        let code = "fn f() { let mut v: Vec<i32> = vec![1].into_iter().collect::<Vec<_>>(); v.iter_mut(); }";
+        // This should NOT flag because `v.iter_mut()` is on a variable, not chained on collect
+        let diags = parse_and_check(code);
+        assert!(
+            diags.is_empty(),
+            "variable access should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn test_collect_iter_mut_chained_detected() {
+        let code =
+            "fn f() { let _ = vec![1i32].into_iter().collect::<Vec<_>>().iter_mut().count(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("iter_mut"));
+    }
+
+    #[test]
+    fn test_collect_len_detected() {
+        let code = "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().len(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains(".count()"));
+    }
+
+    #[test]
+    fn test_collect_is_empty_detected() {
+        let code = "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().is_empty(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains(".next().is_none()"));
+    }
+
+    #[test]
+    fn test_collect_first_detected() {
+        let code = "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().first(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains(".next()"));
+    }
+
+    #[test]
+    fn test_collect_last_detected() {
+        let code = "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().last(); }";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("`.last()` on the iterator"));
+    }
+
+    #[test]
+    fn test_plain_collect_without_turbofish() {
+        let code = r"
+fn f() {
+    let v: Vec<i32> = vec![1, 2, 3];
+    let _ = v.iter().collect::<Vec<_>>().len();
+}
+";
+        let diags = parse_and_check(code);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains(".count()"));
+    }
+
+    #[test]
+    fn test_collect_then_push_not_flagged() {
+        let code =
+            "fn f() { let mut v: Vec<i32> = vec![1].into_iter().collect::<Vec<_>>(); v.push(2); }";
+        let diags = parse_and_check(code);
+        assert!(diags.is_empty(), "push is not a flagged method: {diags:?}");
+    }
+
+    #[test]
+    fn test_collect_then_unflagged_method_not_flagged() {
+        let code = "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().contains(&1); }";
+        let diags = parse_and_check(code);
+        assert!(
+            diags.is_empty(),
+            "contains is not a flagged method: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn test_no_collect_not_flagged() {
+        let code = "fn f() { let v = vec![1,2,3]; let _ = v.iter().count(); }";
+        let diags = parse_and_check(code);
+        assert!(diags.is_empty(), "no collect call: {diags:?}");
+    }
+
+    #[test]
+    fn test_deny_level_propagated() {
+        let config = Config {
+            level: RuleLevel::Deny,
+        };
+        let code = "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().len(); }";
+        let diags = parse_and_check_with_config(code, &config);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].level, RuleLevel::Deny);
+    }
+
+    #[test]
+    fn test_intermediate_method_not_flagged() {
+        let code =
+            "fn f() { let _ = vec![1,2,3].into_iter().collect::<Vec<_>>().as_slice().iter(); }";
+        let diags = parse_and_check(code);
+        // .as_slice() breaks the chain — iter() sees as_slice() as receiver, not collect()
+        assert!(
+            diags.is_empty(),
+            "intermediate method should break detection: {diags:?}"
+        );
+    }
+}

--- a/src/rules/ast/mod.rs
+++ b/src/rules/ast/mod.rs
@@ -1,5 +1,6 @@
 pub mod allow_audit;
 pub mod clone_density;
+pub mod collect_then_iterate;
 pub mod glob_imports;
 pub mod magic_numbers;
 pub mod undocumented_panic;

--- a/tests/fixtures/collect_then_iterate.rs
+++ b/tests/fixtures/collect_then_iterate.rs
@@ -1,0 +1,45 @@
+// Test fixture for collect-then-iterate rule
+
+fn collect_then_iter() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().iter().count();
+}
+
+fn collect_then_into_iter() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().into_iter().count();
+}
+
+fn collect_then_iter_mut() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().iter_mut().count();
+}
+
+fn collect_then_len() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().len();
+}
+
+fn collect_then_is_empty() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().is_empty();
+}
+
+fn collect_then_first() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().first();
+}
+
+fn collect_then_last() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().last();
+}
+
+// --- Clean examples (should NOT be flagged) ---
+
+fn collect_then_push() {
+    let mut v: Vec<i32> = vec![1].into_iter().collect();
+    v.push(2);
+}
+
+fn no_collect() {
+    let v = vec![1, 2, 3];
+    let _ = v.iter().count();
+}
+
+fn collect_with_intermediate() {
+    let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>().as_slice().iter();
+}

--- a/tests/int_collect_then_iterate.rs
+++ b/tests/int_collect_then_iterate.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::unwrap_used)]
+
+mod test_helpers;
+
+use cargo_lint_extra::config::Config;
+use cargo_lint_extra::diagnostic::RuleLevel;
+
+#[test]
+fn test_collect_then_iterate_detected() {
+    let mut config = Config::default();
+    config.rules.collect_then_iterate.level = RuleLevel::Warn;
+    let diags = test_helpers::run_on_fixture("collect_then_iterate.rs", &config);
+    let rule_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| d.rule == "collect-then-iterate")
+        .collect();
+    assert_eq!(
+        rule_diags.len(),
+        7,
+        "expected 7 collect-then-iterate diagnostics, got {}: {rule_diags:?}",
+        rule_diags.len()
+    );
+}
+
+#[test]
+fn test_collect_then_iterate_disabled() {
+    let mut config = Config::default();
+    config.rules.collect_then_iterate.level = RuleLevel::Allow;
+    let diags = test_helpers::run_on_fixture("collect_then_iterate.rs", &config);
+    assert!(
+        !diags.iter().any(|d| d.rule == "collect-then-iterate"),
+        "Allow level should produce no diagnostics"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a new AST rule `collect-then-iterate` that flags `.collect().iter()` and similar anti-patterns where a collection is built only to be immediately consumed, allocating unnecessarily. Common in AI-generated code; Clippy doesn't catch this.
- Detects 7 follow-up methods chained directly on `.collect()` with tailored suggestions:
  - `.iter()` / `.into_iter()` / `.iter_mut()` → continue using the iterator chain directly
  - `.len()` → use `.count()`
  - `.is_empty()` → use `.next().is_none()`
  - `.first()` → use `.next()`
  - `.last()` → use `.last()` on the iterator
- Defaults to `Warn`. Handles both turbofish (`.collect::<Vec<_>>()`) and plain `.collect()`. Only flags immediate chaining — intermediate methods (`.collect().as_slice().iter()`) and variable bindings (`let v = .collect(); v.iter()`) are intentionally not flagged.

Closes #11

## Test plan
- [x] 14 unit tests in `src/rules/ast/collect_then_iterate.rs` cover all 7 follow-up methods, turbofish vs plain, intermediate-method break, variable-binding non-match, unflagged methods, no-collect case, and `Deny` level propagation
- [x] 2 integration tests in `tests/int_collect_then_iterate.rs` verify the 7-diagnostic count and `Allow`-level disable
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 257 passed
- [x] `cargo run -- lint-extra .` self-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)