### PR TITLE
fix: -W should not force exit 1 when no diagnostics (#27)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,8 +107,9 @@ fn main() {
         }
     }
 
-    let has_errors =
-        args.warnings_as_errors || diagnostics.iter().any(|d| d.level == RuleLevel::Deny);
+    let any_deny = diagnostics.iter().any(|d| d.level == RuleLevel::Deny);
+    let escalate_warnings = args.warnings_as_errors && !diagnostics.is_empty();
+    let has_errors = any_deny || escalate_warnings;
     process::exit(i32::from(has_errors));
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -191,6 +191,23 @@ fn test_warnings_as_errors_flag() {
 }
 
 #[test]
+fn test_warnings_as_errors_flag_exits_zero_on_clean_run() {
+    let dir = fixture_dir("clean.rs", "warn-as-err-clean");
+    let output = Command::new(cargo_bin())
+        .args(["lint-extra", "-W"])
+        .arg(dir.to_str().unwrap())
+        .output()
+        .expect("failed to run binary");
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "warnings-as-errors should exit 0 when no diagnostics, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_config_flag_migrates_deprecated_max() {
     let dir = fixture_dir("clean.rs", "config-max");
     let config_path = dir.join(".cargo-lint-extra.toml");


### PR DESCRIPTION
## Summary
- Fixes a bug where \`cargo lint-extra -W\` (\`--warnings-as-errors\`) exited 1 even when zero diagnostics were produced, contradicting the documented behavior and breaking CI use as a strict-mode gate.
- Root cause: \`args.warnings_as_errors || diagnostics.iter().any(...)\` short-circuited the boolean OR before checking whether \`diagnostics\` was empty.
- Fix: split into \`any_deny\` and \`escalate_warnings\`, gating warning escalation on \`!diagnostics.is_empty()\`.

Closes #27

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| No diagnostics, no \`-W\` | exit 0 | exit 0 |
| No diagnostics, \`-W\` | exit 1 ❌ | exit 0 ✅ |
| Warnings only, no \`-W\` | exit 0 | exit 0 |
| Warnings only, \`-W\` | exit 1 | exit 1 |
| Any \`Deny\` | exit 1 | exit 1 |

## Test plan
- [x] New regression test \`test_warnings_as_errors_flag_exits_zero_on_clean_run\` runs \`-W\` against \`tests/fixtures/clean.rs\` and asserts exit 0 (would fail RED against the buggy code)
- [x] Existing \`test_warnings_as_errors_flag\` (warnings + \`-W\` → 1) still green
- [x] Existing \`test_exit_code_1_errors\` (Deny → 1) still green
- [x] \`cargo fmt\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — 258 passed
- [x] \`cargo run -- lint-extra .\` self-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)