### PR TITLE
chore: add /implement-issue context loader script

### DIFF
--- a/.claude/commands/implement-issue.md
+++ b/.claude/commands/implement-issue.md
@@ -1,0 +1,349 @@
+# Implement Issue Workflow
+
+You are orchestrating a Plan → Implement → Review → Remediate → PR cycle for a GitHub issue,
+with support for stacked PRs when issues form a linear dependency chain.
+
+## Input
+
+The user will provide a GitHub issue number: $ARGUMENTS
+
+## Phase 1: Load Context & Determine Stacking
+
+1. Run the context loader script to fetch all issue data in one shot:
+   ```
+   .claude/scripts/load-issue-context.sh <number>
+   ```
+   This fetches: issue details (title/body/labels/state), all comments, the full milestone issue list, dependency states (from `#N` mentions in the body), open PRs on `feat/` branches, and current git state. It replaces multiple `gh api` calls with a single invocation.
+2. Read CLAUDE.md for project conventions (especially the "Adding a new rule" checklist)
+3. From the script output, verify all dependencies are complete — either closed/merged to main, or listed in the `=== OPEN FEAT BRANCHES ===` section as part of the current stack
+
+### Stacking Decision
+
+Determine whether this issue should **stack** on a previous branch or **start fresh from main**.
+
+**Algorithm:**
+1. Find this issue's position in the milestone's implementation sequence (from the script's `Milestone` section — the current issue is marked `<-- this issue`)
+2. Look at the **previous issue** in the sequence (by step number, not by dependency list)
+3. If the previous issue has an **unmerged PR branch** that is an ancestor of this issue's dependencies → **stack on that branch**
+4. If the previous issue is already **merged to main** → **branch from main**
+5. If this issue has **multiple unmerged predecessors on different branches** → this is a **merge point**. STOP and tell the user the predecessor PRs must be merged first.
+
+**In practice:**
+The script's `=== OPEN FEATURE BRANCHES ===` section lists all open PRs on `feat/` branches with their head/base. Use this to determine the stacking target:
+
+```
+# If stacking:
+git checkout <predecessor-branch>
+git checkout -b feat/<this-issue>
+
+# If fresh from main (works in worktrees where local main may not exist):
+git fetch origin main
+git checkout -b feat/<this-issue> origin/main
+```
+
+**Stacking stops when:** the next issue in the sequence introduces a new dependency that isn't in the current linear chain. At that point, the accumulated stack should be merged to main before continuing.
+
+Report the stacking decision to the user:
+```
+Stacking: feat/<this-issue> → feat/<predecessor-issue> → ... → main
+PR will target: feat/<predecessor-issue>
+```
+or:
+```
+Fresh branch: feat/<this-issue> from main
+PR will target: main
+```
+
+**IMPORTANT:** Record the stacking decision (base branch and PR target) — this information must be included in the plan so it survives context compression.
+
+## Phase 2: Plan
+
+1. Enter plan mode with `EnterPlanMode`
+2. Explore the codebase areas relevant to the issue:
+   - Read existing rule implementations for the same rule type (text or AST) as reference patterns
+   - Read `src/config.rs` to understand the config struct patterns
+   - Read `src/engine.rs` to understand how rules are wired up
+   - Read `src/main.rs` to understand `set_rule_level()` wiring
+   - Read an existing test fixture and its corresponding integration test for the pattern
+3. Design the implementation approach following the "Adding a new rule" checklist from CLAUDE.md:
+   1. Create `src/rules/text/<rule>.rs` or `src/rules/ast/<rule>.rs`
+   2. Implement `TextRule` or `AstRule` trait with kebab-case `name()`
+   3. Add config struct to `src/config.rs` with `#[serde(default)]` and `Default` impl
+   4. Add field to `RulesConfig` (kebab-case serde rename)
+   5. Wire up in `src/engine.rs` — instantiate only if `level != Allow`
+   6. Add rule name to `set_rule_level()` in `src/main.rs`
+   7. Add test fixture in `tests/fixtures/`
+   8. Write unit tests and integration tests
+   9. Update README.md with rule documentation
+
+### Plan Content Requirements
+
+The plan must be **self-contained** — Claude Code's plan mode keeps the plan file fully loaded after context compression, so the plan becomes the primary reference for all subsequent phases.
+
+#### Section 1: Branch & Stacking
+```markdown
+## Branch Strategy
+- **Branch name:** `feat/<number>-<short-description>`
+- **Base branch:** `main` | `feat/<predecessor-branch>`
+- **PR target:** `main` | `feat/<predecessor-branch>`
+- **Create command:** `git fetch origin <base> && git checkout -b feat/<branch-name> origin/<base>` (worktree-safe; use `git checkout <predecessor-branch> && git checkout -b feat/<branch-name>` when stacking on a local-only branch)
+```
+
+#### Section 2: Implementation Plan
+The actual code changes — files to create/modify, config struct fields, rule detection logic, diagnostic messages.
+
+#### Section 3: Implementation Order
+Numbered steps following TDD:
+1. Create the branch
+2. Add config struct to `src/config.rs`
+3. Create the rule implementation file
+4. Write test fixture with known violations
+5. Write unit tests (expect failures initially)
+6. Implement the rule logic
+7. Run tests to confirm they pass
+8. Wire up in engine and main
+9. Write integration tests
+10. Update README.md
+11. Run quality gate
+
+#### Section 4: Post-Implementation Checklist
+
+```markdown
+## Post-Implementation Checklist
+
+### Quality Gate (run all, fix any failures before review)
+- [ ] `cargo fmt`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+- [ ] `cargo run -- lint-extra .` (self-lint — must produce zero findings)
+
+### Verify new rule works
+- [ ] Run `cargo run -- lint-extra tests/fixtures/<rule_fixture>.rs` and confirm expected diagnostics
+- [ ] Verify inline suppression works: `// cargo-lint-extra:allow(<rule-name>)`
+
+### Multi-Agent Review (4 parallel agents)
+Launch 4 review agents in parallel using the Agent tool:
+1. **Acceptance Criteria** — verify each criterion from the issue with PASS/FAIL
+2. **Code Quality** — file length (500 lines hard limit), function length (60 lines), naming, error handling (no unwrap/expect)
+3. **Architecture** — follows existing rule patterns, config/engine/main wiring correct, `Send + Sync` traits satisfied
+4. **Test Coverage** — unit tests, integration tests, fixture file, edge cases, meaningful assertions
+
+Provide each agent with:
+- The issue description and acceptance criteria
+- The diff command: `git diff <base-branch>...HEAD`
+
+### Remediation
+- Fix all MAJOR findings, re-run quality gate
+- Present MINOR findings to user for decision
+
+### PR Creation
+- Push: `git push -u origin <branch-name>`
+- Create PR: `gh pr create --base <pr-target> --title "..." --body "..."`
+- PR body must include: `Closes #<number>`, summary, test plan
+- If stacked: include Stack section in PR body
+- Wait for CI to pass (`gh pr checks <number> --watch`), fix failures if any
+- Report PR URL and next issue in sequence (if any)
+```
+
+5. Write the plan using the plan mode tool
+6. Exit plan mode and wait for user approval
+
+**STOP: Wait for user to approve the plan before proceeding.**
+
+## Phase 3: Implement
+
+1. **Create the branch** per the Branch Strategy section of the approved plan
+2. Create tasks for each implementation step using TaskCreate
+3. Follow TDD:
+   - Write tests first
+   - Run tests to confirm they fail
+   - Implement the code
+   - Run tests to confirm they pass
+4. Follow project standards from CLAUDE.md:
+   - Line width: 100 chars (rustfmt)
+   - Function length: 60 lines (clippy.toml)
+   - Cognitive complexity: 15 (clippy.toml)
+   - File length: 500 lines (cargo-lint-extra itself)
+   - No `.unwrap()` or `.expect()` in production code
+   - `#[allow(clippy::unwrap_used)]` only in test modules
+5. Mark tasks complete as you go
+
+### Rule Implementation Standards
+
+- Rule `name()` must return kebab-case (e.g., `"clone-density"`)
+- Config struct must derive `Deserialize, Default, Clone` with `#[serde(default)]`
+- Config fields use snake_case, config sections use kebab-case
+- Default level: `Warn` for broadly useful rules, `Allow` for opinionated ones
+- Rule must implement `Send + Sync` for parallel execution
+- Fixture file must contain both triggering and non-triggering code with clear comments
+
+## Phase 4: Quality Gate
+
+Run the full quality gate:
+
+```
+cargo fmt
+cargo clippy --all-targets -- -D warnings
+cargo test
+cargo run -- lint-extra .
+```
+
+The last command (self-lint) is critical — the project lints itself. If the new rule fires on the project's own code, either fix the code or adjust the rule's defaults/config.
+
+If any failures, fix them before proceeding to the multi-agent review.
+
+## Phase 5: Multi-Agent Review
+
+Spawn **four review agents in parallel** using the Agent tool. Each agent reviews **only this issue's changes** from a different perspective.
+
+**Important for stacked PRs:** The diff must be scoped to only this issue's commits, not the entire stack.
+```
+# For stacked PRs (base is predecessor branch):
+git diff <predecessor-branch>...HEAD
+
+# For fresh branches (base is main):
+git diff origin/main...HEAD
+```
+
+**Important:** Agents should use `git diff` output as the source of truth, NOT read individual files directly. Reading files can produce stale results if edits happen between agent launch and file read, and a diff against `main` will appear empty if the changes aren't committed yet — make sure to commit (or at least stage) the implementation before spawning review agents.
+
+### Agent 1: Acceptance Criteria Verification
+**subagent_type:** `general-purpose`
+```
+Review the changes against the issue's acceptance criteria (from the issue's implementation checklist).
+For each criterion, state PASS or FAIL with evidence (file:line references).
+Flag any criteria that are partially met.
+```
+
+### Agent 2: Code Quality & Standards
+**subagent_type:** `general-purpose`
+```
+Review the changes for:
+- File length (hard limit 500 lines)
+- Function length (60 lines max per clippy.toml)
+- Cognitive complexity (15 max per clippy.toml)
+- No .unwrap()/.expect() in production code
+- #[allow(...)] only in test modules
+- Naming: rule names kebab-case, config fields snake_case
+- Config struct has #[serde(default)] and Default impl
+Rate each file: CLEAN, MINOR, or MAJOR.
+```
+
+### Agent 3: Architecture & Integration
+**subagent_type:** `general-purpose`
+```
+Review the changes for:
+- Follows existing rule implementation patterns (compare with similar rules in src/rules/)
+- Config wired correctly in src/config.rs (field in RulesConfig, serde rename)
+- Engine wiring correct in src/engine.rs (instantiate only if level != Allow)
+- CLI wiring correct in src/main.rs (set_rule_level)
+- Rule implements Send + Sync
+- Diagnostic messages are clear and follow existing format
+Rate: CLEAN, MINOR, or MAJOR.
+```
+
+### Agent 4: Test Coverage & Correctness
+**subagent_type:** `general-purpose`
+```
+Review the changes for:
+- Unit tests in #[cfg(test)] module within the rule file
+- Integration tests in tests/integration_test.rs
+- Test fixture in tests/fixtures/ with both triggering and non-triggering code
+- Edge cases tested
+- Tests use #[allow(clippy::unwrap_used)]
+- Fixture file excluded from self-linting via .cargo-lint-extra.toml if needed
+Rate: CLEAN, MINOR, or MAJOR.
+```
+
+### Synthesis
+
+After all four agents complete, produce a structured report:
+
+```markdown
+## Review Summary
+
+### Verdict: PASS / PASS WITH MINOR ITEMS / NEEDS REMEDIATION
+
+### Acceptance Criteria: X/Y passed
+
+### Findings by severity
+
+#### MAJOR (must fix before PR)
+- [ ] <finding> — <file:line> (from: <agent>)
+
+#### MINOR (fix or consciously skip)
+- [ ] <finding> — <file:line> (from: <agent>)
+
+#### NOTES (informational)
+- <observation> (from: <agent>)
+```
+
+## Phase 6: Remediate
+
+If any MAJOR findings:
+1. Fix each MAJOR item
+2. Re-run the quality gate (Phase 4)
+3. Re-run only the relevant review agents for changed areas
+4. Update the review summary
+
+For MINOR findings, present them to the user and let them decide which to address.
+
+**STOP: Present the review summary to the user. Ask for confirmation before creating PR.**
+Use `AskUserQuestion` with options:
+- "Create PR as-is" — proceed to Phase 7
+- "Fix minor items first" — address selected minor items, then re-review
+- "I want to review the changes myself first" — pause, let user inspect
+
+## Phase 7: PR
+
+1. Push the branch: `git push -u origin <branch-name>`
+2. Create the PR with the correct base branch:
+   ```
+   # Stacked PR:
+   gh pr create --base feat/<predecessor-issue> --title "..." --body "..."
+
+   # Fresh from main:
+   gh pr create --base main --title "..." --body "..."
+   ```
+3. PR body format:
+   - Title: `feat: add <rule-name> rule` (matching conventional commits)
+   - Body must include:
+     - `Closes #<number>`
+     - Summary of the rule, its config fields, and default behavior
+     - Test plan
+     - If stacked: a "Stack" section listing the chain
+4. Wait for CI checks to complete:
+   ```
+   gh pr checks <pr-number> --watch
+   ```
+   - If CI fails, investigate, fix, push, and wait again
+5. If there is a next issue in the milestone sequence that can be stacked, inform the user:
+   ```
+   Next in sequence: #<next-issue> — <title>
+   This can be stacked on the branch just created. Run: /implement-issue <next-issue>
+   ```
+
+## Conventions
+
+- Branch naming: `feat/<issue-number>-<short-description>` (e.g., `feat/6-clone-density`)
+- Commit messages: conventional commits (`feat:`, `fix:`, `test:`, `refactor:`), include issue number
+- One logical change per commit
+- Always reference the issue number in commit messages
+
+## Stacking Reference
+
+### When stacking works (linear chain)
+```
+main ← feat/10-redundant-comments ← feat/6-clone-density ← feat/9-glob-imports
+         PR #A (→main)               PR #B (→feat/10)       PR #C (→feat/6)
+```
+Each PR shows only its own diff. Merge from the bottom up.
+
+### When stacking stops (fan-out / merge point)
+If two issues share a dependency but are on different branches, that's a merge point.
+The shared dependency must be merged to main before either can proceed.
+
+### After merging a stacked PR
+When a PR at the base of a stack is merged to main:
+1. Update the next PR's base: `gh pr edit <number> --base main`
+2. Or rebase: `git rebase --onto main feat/<merged-branch> feat/<next-branch>`

--- a/.claude/scripts/load-issue-context.sh
+++ b/.claude/scripts/load-issue-context.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Pre-fetch all context needed for /implement-issue
+# Usage: load-issue-context.sh <issue-number>
+#
+# Outputs a single structured document with:
+# - Issue details (title, body, labels, state)
+# - All issue comments
+# - Milestone issues
+# - Dependency issue states
+# - Open PRs on feat/ branches (for stacking decisions)
+# - Current git branch state
+
+set -euo pipefail
+
+REPO="mpecan/cargo-lint-extra"
+ISSUE_NUM="${1:?Usage: load-issue-context.sh <issue-number>}"
+
+# Colors and symbols (disabled if not a terminal)
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  DIM='\033[2m'
+  CYAN='\033[36m'
+  GREEN='\033[32m'
+  YELLOW='\033[33m'
+  RED='\033[31m'
+  MAGENTA='\033[35m'
+  RESET='\033[0m'
+else
+  BOLD='' DIM='' CYAN='' GREEN='' YELLOW='' RED='' MAGENTA='' RESET=''
+fi
+
+SYM_CHECK="${GREEN}✓${RESET}"
+SYM_OPEN="${YELLOW}○${RESET}"
+SYM_CLOSED="${DIM}●${RESET}"
+
+header() { printf "\n${BOLD}${CYAN}━━━ %s ━━━${RESET}\n\n" "$1"; }
+subheader() { printf "  ${BOLD}%s${RESET}\n" "$1"; }
+
+state_icon() {
+  case "$1" in
+    closed) printf "${SYM_CHECK}" ;;
+    open)   printf "${SYM_OPEN}" ;;
+    *)      printf "?" ;;
+  esac
+}
+
+# --- Issue details ---
+ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}")
+ISSUE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.title')
+ISSUE_STATE=$(echo "$ISSUE_JSON" | jq -r '.state')
+ISSUE_BODY=$(echo "$ISSUE_JSON" | jq -r '.body // ""')
+ISSUE_LABELS=$(echo "$ISSUE_JSON" | jq -r '[.labels[].name] | join(", ")')
+ISSUE_MILESTONE=$(echo "$ISSUE_JSON" | jq -r '.milestone.title // "none"')
+
+header "Issue #${ISSUE_NUM}: ${ISSUE_TITLE}"
+printf "  ${DIM}State:${RESET}     %b %s\n" "$(state_icon "$ISSUE_STATE")" "$ISSUE_STATE"
+printf "  ${DIM}Labels:${RESET}    %s\n" "${ISSUE_LABELS:-none}"
+printf "  ${DIM}Milestone:${RESET} %s\n" "$ISSUE_MILESTONE"
+echo ""
+subheader "Description"
+echo "$ISSUE_BODY" | sed 's/^/  /'
+echo ""
+
+# --- Issue comments ---
+COMMENTS=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
+  --jq '[.[] | {author: .user.login, created_at: .created_at, body: .body}]')
+COMMENT_COUNT=$(echo "$COMMENTS" | jq 'length')
+
+header "Comments (${COMMENT_COUNT})"
+if [ "$COMMENT_COUNT" -gt 0 ]; then
+  echo "$COMMENTS" | jq -r '.[] | .author + " " + .created_at + "\n" + .body' | while IFS= read -r line; do
+    # First line of each comment block is "author date"
+    if echo "$line" | grep -qE '^[a-zA-Z0-9_-]+ [0-9]{4}-'; then
+      AUTHOR=$(echo "$line" | cut -d' ' -f1)
+      DATE=$(echo "$line" | cut -d' ' -f2 | cut -dT -f1)
+      printf "\n  ${BOLD}${MAGENTA}@%s${RESET} ${DIM}(%s)${RESET}\n" "$AUTHOR" "$DATE"
+    else
+      printf "  %s\n" "$line"
+    fi
+  done
+else
+  printf "  ${DIM}(none)${RESET}\n"
+fi
+echo ""
+
+# --- Milestone from GitHub metadata ---
+MILESTONE_NUMBER=$(echo "$ISSUE_JSON" | jq -r '.milestone.number // empty')
+MILESTONE_TITLE=$(echo "$ISSUE_JSON" | jq -r '.milestone.title // empty')
+
+if [ -n "$MILESTONE_NUMBER" ]; then
+  header "Milestone: ${MILESTONE_TITLE}"
+  gh api "repos/${REPO}/issues?milestone=${MILESTONE_NUMBER}&state=all&per_page=100&sort=created&direction=asc" \
+    --jq '.[] | "\(.state) #\(.number) \(.title)"' | while IFS= read -r line; do
+      STATE=$(echo "$line" | cut -d' ' -f1)
+      REST=$(echo "$line" | cut -d' ' -f2-)
+      NUM=$(echo "$REST" | cut -d' ' -f1)
+      TITLE=$(echo "$REST" | cut -d' ' -f2-)
+      if [ "$NUM" = "#${ISSUE_NUM}" ]; then
+        printf "  %b %s ${BOLD}%s${RESET} ${YELLOW}<-- this issue${RESET}\n" "$(state_icon "$STATE")" "$NUM" "$TITLE"
+      else
+        printf "  %b %s %s\n" "$(state_icon "$STATE")" "$NUM" "$TITLE"
+      fi
+    done
+  echo ""
+else
+  header "Milestone"
+  printf "  ${DIM}(no milestone assigned)${RESET}\n\n"
+fi
+
+# --- Dependency states ---
+DEP_NUMS=$(echo "$ISSUE_BODY" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un || true)
+if [ -n "$DEP_NUMS" ]; then
+  header "Dependencies"
+  ALL_MET=true
+  for DN in $DEP_NUMS; do
+    if [ "$DN" != "$ISSUE_NUM" ]; then
+      DEP_JSON=$(gh api "repos/${REPO}/issues/${DN}" 2>/dev/null || echo '{}')
+      DEP_STATE=$(echo "$DEP_JSON" | jq -r '.state // "unknown"')
+      DEP_TITLE=$(echo "$DEP_JSON" | jq -r '.title // "(failed to fetch)"')
+      printf "  %b #%-3s %s\n" "$(state_icon "$DEP_STATE")" "$DN" "$DEP_TITLE"
+      if [ "$DEP_STATE" != "closed" ]; then ALL_MET=false; fi
+    fi
+  done
+  echo ""
+  if $ALL_MET; then
+    printf "  ${GREEN}All dependencies met.${RESET}\n\n"
+  else
+    printf "  ${RED}Warning: some dependencies are still open.${RESET}\n\n"
+  fi
+fi
+
+# --- Open PRs on feat/ branches ---
+header "Open Feature Branches"
+PR_OUTPUT=$(gh pr list --repo "$REPO" --state open \
+  --json number,headRefName,baseRefName,title \
+  --jq '.[] | select(.headRefName | startswith("feat/")) | "#\(.number)|\(.headRefName)|\(.baseRefName)|\(.title)"')
+
+if [ -n "$PR_OUTPUT" ]; then
+  echo "$PR_OUTPUT" | while IFS='|' read -r NUM HEAD BASE TITLE; do
+    printf "  ${BOLD}%-6s${RESET} %s ${DIM}→ %s${RESET}\n" "$NUM" "$HEAD" "$BASE"
+    printf "         ${DIM}%s${RESET}\n" "$TITLE"
+  done
+else
+  printf "  ${DIM}(none)${RESET}\n"
+fi
+echo ""
+
+# --- Current git state ---
+header "Git State"
+BRANCH=$(git branch --show-current)
+DIRTY_COUNT=$(git status --porcelain | wc -l | tr -d ' ')
+printf "  ${DIM}Branch:${RESET}    %s\n" "$BRANCH"
+if [ "$DIRTY_COUNT" -eq 0 ]; then
+  printf "  ${DIM}Working tree:${RESET} ${GREEN}clean${RESET}\n"
+else
+  printf "  ${DIM}Working tree:${RESET} ${YELLOW}%s uncommitted file(s)${RESET}\n" "$DIRTY_COUNT"
+fi
+echo ""


### PR DESCRIPTION
## Summary

Ports the issue-context loader pattern from [\`mpecan/kiez_fyi\`](https://github.com/mpecan/kiez_fyi). A single \`.claude/scripts/load-issue-context.sh <num>\` invocation now replaces multiple inline \`gh api\` / \`gh pr list\` calls during Phase 1 of \`/implement-issue\`.

## What the script fetches

One invocation pulls:
- Issue details (title, body, labels, state, milestone)
- All issue comments
- The full milestone issue list (with the current issue marked \`<-- this issue\`)
- Dependency issue states (parsed from \`#N\` mentions in the body)
- Open PRs on \`feat/\` branches — directly usable for stacking decisions
- Current git branch and dirty-tree status

Script is adapted from kiez_fyi with only \`REPO=\"mpecan/cargo-lint-extra\"\` changed.

## Other workflow improvements ported from kiez_fyi

- **Phase 2 branch create** uses \`git fetch origin <base> && git checkout -b ... origin/<base>\` — worktree-safe
- **Phase 5** strengthens the "use \`git diff\` not file reads" guidance with an explicit reminder to **commit or stage** changes before spawning review agents (a lesson from a recent session where two review agents saw an empty diff because the implementation was still uncommitted)
- **Phase 6** uses explicit \`AskUserQuestion\` options when presenting the review summary

## Preserved

All cargo-lint-extra-specific content is untouched:
- The "Adding a new rule" checklist
- The \`cargo fmt\` / \`cargo clippy --all-targets -- -D warnings\` / \`cargo test\` / \`cargo run -- lint-extra .\` quality gate
- The 500-line file limit and 60-line function limit
- Self-lint verification step
- Rule implementation standards (kebab-case \`name()\`, \`#[serde(default)]\`, \`Send + Sync\`)
- Project-specific review agent criteria (file/function length, cognitive complexity 15, no unwrap/expect in production, rule patterns, engine wiring)

## Test plan
- [x] Script runs cleanly: \`./.claude/scripts/load-issue-context.sh 12\` produces formatted context for issue #12 (verbose-result-handling)
- [x] Script is executable (\`chmod +x\`)
- [x] No behavior change to project code — \`.claude/\` is a tooling-only directory
- [ ] Dogfood: the next \`/implement-issue\` run should use the new script (manual verification by the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)